### PR TITLE
(doc) Remove AU badges and clarify our fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-[![build](https://ci.appveyor.com/api/projects/status/github/majkinetor/au?svg=true)](https://ci.appveyor.com/project/majkinetor/au)   [![chat](https://img.shields.io/badge/gitter-join_chat-1dce73.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB4PSIwIiB5PSI1IiBmaWxsPSIjZmZmIiB3aWR0aD0iMSIgaGVpZ2h0PSI1Ii8%2BPHJlY3QgeD0iMiIgeT0iNiIgZmlsbD0iI2ZmZiIgd2lkdGg9IjEiIGhlaWdodD0iNyIvPjxyZWN0IHg9IjQiIHk9IjYiIGZpbGw9IiNmZmYiIHdpZHRoPSIxIiBoZWlnaHQ9IjciLz48cmVjdCB4PSI2IiB5PSI2IiBmaWxsPSIjZmZmIiB3aWR0aD0iMSIgaGVpZ2h0PSI0Ii8%2BPC9zdmc%2B&logoWidth=8)](https://gitter.im/chocolatey_au/Lobby)   [![license](https://img.shields.io/badge/license-GPL2-blue.svg)](https://raw.githubusercontent.com/majkinetor/au/master/license.txt)
-
----
-
-**The development of AU is finished and there will be no new versions. The latest version is 2022.10.24.**
-
----
+> NOTE: This PowerShell module is maintained by the Chocolatey Community as the original maintainer [archived the repository](https://github.com/majkinetor/au/commit/7f9c84e1e15995595dae68b4e8d8a71f50417752). To avoid confusion, and allow easier differentiation, this project has been named `chocolatey-au`. Chocolatey and the Chocolatey Community thanks [majkinetor](https://github.com/majkinetor) for their work on the module over the years.
+>
+> Please bear with us while we release the first build and update the documentation. In the meantime, there will continue to be reference to AU within the documentation.
 
 # Chocolatey Automatic Package Updater Module
 


### PR DESCRIPTION
This PR removes the AU specific badges and archive notice from the README and adds a notice to reassure users.