### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AU module requires minimally PowerShell version 5: `$host.Version -ge '5.0'`
 
 To install it, use one of the following methods:
 - PowerShell Gallery: [`Install-Module au`](https://www.powershellgallery.com/packages/AU).
-- Chocolatey:  [`cinst au`](https://chocolatey.org/packages/au).
+- Chocolatey:  [`choco install au`](https://chocolatey.org/packages/au).
 - [Download](https://github.com/majkinetor/au/releases/latest) latest 7z package or latest build [artifact](https://ci.appveyor.com/project/majkinetor/au/build/artifacts).
 
 


### PR DESCRIPTION
Changed "cinst au" to "choco install au" because cinst is depreciated.