### PR TITLE
Reimplement RunInfo plugin's deep_clone function for PowerShell 7.4+ compatibility

### DIFF
--- a/src/Plugins/RunInfo.ps1
+++ b/src/Plugins/RunInfo.ps1
@@ -22,11 +22,8 @@ param(
 function deep_clone {
     param($DeepCopyObject)
 
-    $memStream = new-object IO.MemoryStream
-    $formatter = new-object Runtime.Serialization.Formatters.Binary.BinaryFormatter
-    $formatter.Serialize($memStream,$DeepCopyObject)
-    $memStream.Position=0
-    $formatter.Deserialize($memStream)
+    $serializedObject = [System.Management.Automation.PSSerializer]::Serialize($DeepCopyObject, 32)
+    [System.Management.Automation.PSSerializer]::Deserialize($serializedObject)
 }
 
 # Runinfo must save its own run results directly in Info


### PR DESCRIPTION
Fixes #38.

While I've only observed a maximum depth of 16 members locally for my packages, I went with a maximum depth of 32 to provide room for possible future expansion before we need to worry about AU-imposed truncation.

## Testing

For validation purposes, this change was manually patched into an existing `AU` v2022.10.24 installation (as this issue came up prior to `chocolatey-au`'s first release).

The following files were patched:

- Windows PowerShell: `%PROGRAMFILES%\WindowsPowerShell\Modules\AU\Plugins\RunInfo.ps1`
- PowerShell 7: `%USERPROFILE%\PowerShell\Modules\AU\2022.10.24\Plugins\RunInfo.ps1`

Executed `update_all.ps1` from my local repository based on [`au-packages-template`](https://github.com/majkinetor/au-packages-template) to invoke the Plugin from Windows PowerShell 5.0 (within a clean VM built around Windows 10 Pro v1507, 64-bit), Windows PowerShell 5.1 and PowerShell 7.4 (both from my dev environment: Windows 11 Pro 22H2).

Compared the resulting `update_info.xml` files and looked for notable serialization differences from a pre-patched run. Nothing jumped out at me as being potentially problematic.
