### PR TITLE
(#45) Update build process with release findings

### DIFF
--- a/.github/ISSUE_TEMPLATE/zNewRelease.md
+++ b/.github/ISSUE_TEMPLATE/zNewRelease.md
@@ -22,7 +22,7 @@ For the steps requiring a Chocolatey Team Member, reach out to one of the team m
 - [ ] Make sure all issues in the upcoming milestone have only one type label associated (A type label would be labels such as `Feature`, `Improvement`, `Enhancement`, `Bug Fix`, etc).
 - [ ] If the GitHub milestone issues are still open, confirm that they are done before moving on. If they are in fact done, apply the `Done` label and close the issue.
 - [ ] Update the GitHub milestones description if there is a need for any custom words that should be part of the release notes.
-- [ ] Run the following command to generate release notes `gitreleasemanager.exe -m <release_version_here> --token $env:GITRELEASEMANAGER_PAT -o chocolatey-community -r chocolatey-au`
+- [ ] Run the following command to generate release notes `gitreleasemanager.exe create -m <release_version_here> --token $env:GITRELEASEMANAGER_PAT -o chocolatey-community -r chocolatey-au`
   - [ ] **NOTE:** This expects that you have GitReleaseManager installed. If you do not, it can be installed with `choco install gitreleasemanager.portable --confirm`
   - [ ] **NOTE:** If doing an alpha/beta release, don't run this step, instead generate the release notes manually. GitReleaseManager uses labels and milestones to generate the release notes, and therefore won't understand what needs to be done, especially when there are multiple alpha/beta releases.
   - [ ] Before running the above command, make sure you have set the environment variable `GITRELEASEMANAGER_PAT` to your own access token. This can be set through PowerShell with `$env:GITRELEASEMANAGER_PAT = "<token>"`. This token requires access to the labels, milestones, issues, pull requests and releases API.
@@ -37,9 +37,11 @@ For the steps requiring a Chocolatey Team Member, reach out to one of the team m
   - [ ] `git push origin` - here origin is assumed to be your fork on the above repository
 - [ ] Assuming everyone is happy, Publish the GitHub release.
   - [ ] This will trigger a tagged build on a private CI system. **NOTE:** Contact a Chocolatey Team Member about sending you the package artifact once it has been built if you have no access to internal systems.
+  - [ ] The triggered build from the private CI system will automatically publish to The PowerShell Gallery.
   - [ ] Save the package acquired from the internal systems, or a Team Member to a local directory on your local system.
 - [ ] Verify that the package can be installed and that it can be uninstalled.
   - [ ] Run `choco install chocolatey-au --source="'C:\testing'"` (_replace `C:\testing` with the location you sawed the package to_) and ensure that it successfully installs (_use upgrade if it was already installed_).
+  - [ ] Run `Import-Module Chocolatey-AU` and ensure that the module imports successfully.
   - [ ] Run `choco uninstall chocolatey-au` and verify the package was successfully uninstalled.
 - [ ] Go back to the releases page, and upload the package artifact `chocolatey-au` to the release.
 - [ ] Push or ask a Chocolatey Team Member to push the previously uploaded artifact to the Chocolatey Community Repository (_Wait on confirmation that this has been pushed, and is pending moderation before moving further_).

--- a/Chocolatey-AU.build.ps1
+++ b/Chocolatey-AU.build.ps1
@@ -43,11 +43,11 @@ param(
 
 
     [string]
-    $ChocolateyNugetApiKey = $env:CHOCOOPSPUSH_API_KEY,
+    $ChocolateyNugetApiKey = $env:NUGETDEVPUSH_API_KEY,
 
 
     [string]
-    $ChocolateyPublishUrl = $env:CHOCOOPSPUSH_SOURCE,
+    $ChocolateyPublishUrl = $env:NUGETDEVPUSH_SOURCE,
 
 
     [string]
@@ -64,6 +64,7 @@ $script:SourceFolder = "$PSScriptRoot/src"
 $script:ReleaseBuild = -not [string]::IsNullOrEmpty((git tag --points-at HEAD 2> $null) -replace '^v')
 $script:BuildVersion = $null
 $script:IsPrerelease = $false
+$script:IsPullRequest = $false
 $script:ModuleOutputDir = "$OutputDirectory/$ModuleName"
 
 
@@ -193,6 +194,7 @@ task Build Clean, InstallGitVersion, ScriptAnalyzer, {
 
     $gitversion | Out-String -Width 120 | Write-Host
     $versionInfo = $gitversion 2>$null | ConvertFrom-Json
+    $script:IsPullRequest = $versionInfo.BranchName -match '(changes|pull|pull-requests|merge-requests)'
     $manifestUpdates = @{
         Path          = $manifest.FullName
         ModuleVersion = $versionInfo.MajorMinorPatch
@@ -335,13 +337,14 @@ task Sign -After Build {
 }
 
 # Synopsis: publish $ModuleName either internally or to the PSGallery
-task Publish -If ($script:ReleaseBuild -or $PublishUrl) Build, {
+task Publish -If ((-not $script:IsPullRequest) -and ($script:ReleaseBuild -or $PublishUrl)) Build, {
     if (-not (Test-Path $OutputDirectory)) {
         throw 'Build the module with `Invoke-Build` or `build.ps1` before attempting to publish the module'
     }
 
     if (-not $NugetApiKey -or -not $ChocolateyNugetApiKey) {
-        throw 'Please pass the API key for publishing to both the `-NugetApiKey` and `-ChocolateyNugetApiKey` parameter or set $env:POWERSHELLPUSH_API_KEY and $env:CHOCOOPSPUSH_API_KEY before publishing'
+        Write-Warning 'Please pass the API key for publishing to both the `-NugetApiKey` and `-ChocolateyNugetApiKey` parameter or set $env:POWERSHELLPUSH_API_KEY and $env:NUGETDEVPUSH_API_KEY before publishing.'
+        return
     }
 
     $psdFile = Resolve-Path $script:ModuleOutputDir
@@ -380,6 +383,11 @@ task Publish -If ($script:ReleaseBuild -or $PublishUrl) Build, {
     }
 
     if ($script:ReleaseBuild) {
+        if ($null -eq $env:POWERSHELLGALLERY_API_KEY) {
+            Write-Warning "Tagged build, but no API key present. Not publishing build to PowerShell Gallery."
+            return
+        }
+
         Write-Verbose "Publishing to PSGallery"
         $publishParams.NugetApiKey = $env:POWERSHELLGALLERY_API_KEY
         $publishParams.Repository = 'PSGallery'

--- a/chocolatey/chocolatey-au.nuspec
+++ b/chocolatey/chocolatey-au.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
@@ -10,6 +10,7 @@
     <summary>Chocolatey-AU is Powershell module that helps you to automate Chocolatey package updates</summary>
     <description></description>
     <projectUrl>https://github.com/chocolatey-community/chocolatey-au</projectUrl>
+    <iconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</iconUrl>
     <tags>admin powershell module package chocolatey update</tags>
     <copyright>Miodrag Milić, Chocolatey Community</copyright>
     <licenseUrl>https://www.gnu.org/licenses/gpl-2.0.txt</licenseUrl>


### PR DESCRIPTION
## Description Of Changes

Update the build process based on the findings of the 1.0.0 release.

- Do not publish artifacts on a PR build.
- Do not fail build on missing publish tokens, instead print a warning and gracefully exit.
- Add icon to the Chocolatey Package.
- Update Chocolatey Package encoding to correct display issue on Chocolatey Community Repository.

## Motivation and Context

Minor things discovered during the release of 1.0.0.

## Testing

- Run `git tag 1.0.1` to generate a git tag locally.
- Run `./build.ps1 -Task CI`
- Ensure that warning emitted on the publish step that the package was not published due to not having publishing keys.
- Push the build package to the test Community Repository.
- Ensure icon and software author's display correctly on test Community Repository.
- Ensure that Team City build does not publish to internal repositories.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build Process updates

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #45 