### PR TITLE
Replace Invoke-WebRequest with .NET webclient to speed up downloads in Get-RemoteChecksum function

### DIFF
--- a/src/Public/Get-RemoteChecksum.ps1
+++ b/src/Public/Get-RemoteChecksum.ps1
@@ -8,7 +8,8 @@
 #>
 function Get-RemoteChecksum( [string] $Url, $Algorithm='sha256', $Headers ) {
     $fn = [System.IO.Path]::GetTempFileName()
-    Invoke-WebRequest $Url -OutFile $fn -UseBasicParsing -Headers $Headers
+    $wc = New-Object net.webclient
+    $wc.DownloadFile($Url, $fn)
     $res = Get-FileHash $fn -Algorithm $Algorithm | ForEach-Object Hash
     Remove-Item $fn -ea ignore
     return $res.ToLower()

--- a/src/Public/Get-RemoteChecksum.ps1
+++ b/src/Public/Get-RemoteChecksum.ps1
@@ -1,5 +1,5 @@
 # Author: Miodrag Milic <miodrag.milic@gmail.com>
-# Last Change: 22-May-2024.
+# Last Change: 3-June-2024.
 
 <#
 .SYNOPSIS
@@ -8,10 +8,19 @@
 #>
 function Get-RemoteChecksum( [string] $Url, $Algorithm='sha256', $Headers ) {
     $fn = [System.IO.Path]::GetTempFileName()
-    $wc = New-Object net.webclient
-    $wc.DownloadFile($Url, $fn)
-    $res = Get-FileHash $fn -Algorithm $Algorithm | ForEach-Object Hash
+    
+	$originalShowProgress=$ProgressPreference
+	if (-not $showProgress)
+	{
+		$ProgressPreference = 'SilentlyContinue'
+	}
+	Invoke-WebRequest $Url -OutFile $fn -UseBasicParsing -Headers $Headers
+	if (-not $showProgress)
+	{
+		$ProgressPreference = $originalShowProgress
+	}
+    
+	$res = Get-FileHash $fn -Algorithm $Algorithm | ForEach-Object Hash
     Remove-Item $fn -ea ignore
     return $res.ToLower()
 }
-

--- a/src/Public/Get-RemoteChecksum.ps1
+++ b/src/Public/Get-RemoteChecksum.ps1
@@ -1,5 +1,5 @@
 # Author: Miodrag Milic <miodrag.milic@gmail.com>
-# Last Change: 26-Nov-2016.
+# Last Change: 22-May-2024.
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
## Description Of Changes
Updating the Get-RemoteChecksum function to leverage the .NET webclient vs 
the Invoke-WebRequest to speed up the process significantly.

## Motivation and Context
The current Get_RemoteChecksum implementation uses Invoke-WebRequest
which can be slow on larger files. This results in a long checksumming
process during automated packaging. By switching to the .NET webclient,
while losing the "interactive" download update (ie the ticker across the screen), 
we significantly increase the speed of the download. For example, on a 150 mb 
file, it went from minutes to download to seconds.

## Testing
1. This was tested locally on a windows 11 system using the ./update.sh and au_beforeupdate()
2. This was tested within the chocolatey linux docker image using the ./update.sh and au_beforeupdate()

### Operating Systems Testing
- Windows 11 (Powershell 5)
- chocolatey docker image with pwsh 7

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [X] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Issue #58 

Fixes #58 

