### PR TITLE
Ensure checksums are always defined when requested

### DIFF
--- a/src/Public/Update-Package.ps1
+++ b/src/Public/Update-Package.ps1
@@ -129,12 +129,13 @@ function Update-Package {
             $Env:ChocolateyPackageVersion      = $global:Latest.Version.ToString()
             $Env:ChocolateyAllowEmptyChecksums = 'true'
             foreach ($a in $arch) {
+                "Checking hash for $a bit version..." | result
                 $Env:chocolateyForceX86 = if ($a -eq '32') { 'true' } else { '' }
                 try {
                     #rm -force -recurse -ea ignore $pkg_path
                     .\tools\chocolateyInstall.ps1 | result
                 } catch {
-                    if ( "$_" -notlike 'au_break: *') { throw $_ } else {
+                    if ( "$_" -notlike 'au_break: *') { throw } else {
                         $filePath = "$_" -replace 'au_break: '
                         if (!(Test-Path $filePath)) { throw "Can't find file path to checksum" }
 
@@ -152,6 +153,10 @@ function Update-Package {
                             "Package downloaded and hash checked for $a bit version" | result
                         }
                     }
+                }
+                # Sanity check: ensure checksum is defined (rare bug!)
+                if (!$global:Latest.Item('Checksum' + $a)) {
+                    throw "Hash for $a bit version is missing."
                 }
             }
         }


### PR DESCRIPTION
## Description Of Changes

Throws an error in case a requested checksum is missing.

## Motivation and Context

I don't really understand why but using AU, I ended once having no checksums even though they are usually always automatically calculated by AU.

This change is meant to catch this issue as early as possible.

## Testing

N/A

### Operating Systems Testing

- Windows 11
- Windows Server 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Supersedes #30