### PR TITLE
(docs) Updated hyperlink in README.md from 'au' to 'chocolatey-au'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Chocolatey-AU module requires minimally PowerShell version 5: `$host.Version -ge
 
 To install it, use one of the following methods:
 - PowerShell Gallery: [`Install-Module chocolatey-au`](https://www.powershellgallery.com/packages/Chocolatey-AU).
-- Chocolatey:  [`choco install chocolatey-au`](https://chocolatey.org/packages/au).
+- Chocolatey:  [`choco install chocolatey-au`](https://chocolatey.org/packages/chocolatey-au).
 - [Download](https://github.com/chocolatey-community/chocolatey-au/releases/latest) latest Chocolatey Package from GitHub.
 
 To quickly start using Chocolatey-AU, fork [au-packages-template](https://github.com/majkinetor/au-packages-template) repository and rename it to `au-packages`.


### PR DESCRIPTION
## Description Of Changes
Changed the hyperlink on line 32 of the README.md file to point to `https://chocolatey.org/packages/chocolatey-au` instead of `https://chocolatey.org/packages/au`

## Motivation and Context
The hyperlink should match the package the text refers to.

## Testing
Checked the link in the updated README.md led to the correct package.
 
### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [X] Documentation changes.
* [ ] PowerShell code changes.

## Related Issue

Fixes #66 