### PR TITLE
Switch metapackage example from cpu-z to autohotkey, which is community maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Metapackages can reuse an Chocolatey-AU updater of its dependency by the followi
 
 - In the metapackage updater dot source the dependent updater and override `au_SearchReplace`.
 
-This is best understood via example - take a look at the [cpu-z](https://github.com/majkinetor/au-packages/blob/master/cpu-z/update.ps1) Chocolatey-AU updater which uses the updater from the [cpu-z.install](https://github.com/majkinetor/au-packages/blob/master/cpu-z.install/update.ps1) package on which it depends. It overrides the `au_SearchReplace` function and the `update` call but keeps the `au_GetLatest`.
+This is best understood via example - take a look at the [autohotkey](https://github.dev/chocolatey-community/chocolatey-packages/blob/master/automatic/autohotkey/update.ps1) Chocolatey-AU updater which uses the updater from the [autohotkey.install](https://github.dev/chocolatey-community/chocolatey-packages/blob/master/automatic/autohotkey.install/update.ps1) package on which it depends. It overrides the `au_SearchReplace` function and the `update` call but keeps the `au_GetLatest`.
 
 ### Embedding binaries
 


### PR DESCRIPTION
## Description Of Changes
Switch metapackage example from cpu-z to autohotkey, which is community maintained.

> - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.

There is no CONTRIB*.md document in this repo. The one in chocolatey-au doesn't mention anything about git commit message formatting. So I am going with my own random commit message & eagerly awaiting pushback.

I will send a separate PR to update autohotkey to use this format. Originally I was going to use 7zip but it is too complicated to use for an example. For now, updating to a community-maintained package still provides value because it allows these types of edits, updates to Chocolatey-AU, etc.

## Motivation and Context
Having community maintained packages as examples, 

## Testing
### Operating Systems Testing
None - N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

[Fixes #69](https://github.com/chocolatey-community/chocolatey-au/issues/69)
